### PR TITLE
Get all markets/ US 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,6 @@ end
 group :test do
   gem "shoulda-matchers"
   gem "factory_bot_rails"
-  gem "faker"
+  gem 'faker'
   gem "capybara"
 end

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,0 +1,6 @@
+class Api::V0::MarketsController < ApplicationController
+    def index
+        markets = Market.all
+        render json: MarketSerializer.new(markets).serializable_hash
+    end
+end

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -10,4 +10,8 @@ class Market < ApplicationRecord
   validates :zip, presence: true
   validates :lat, presence: true
   validates :lon, presence: true
+
+  def vendor_count_calc 
+    vendors.count
+  end
 end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -1,0 +1,9 @@
+class MarketSerializer
+    include JSONAPI::Serializer
+  
+    attributes :name, :street, :city, :county, :state, :zip, :lat, :lon
+
+    attribute :vendor_count do |market|
+        market.vendor_count_calc
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v0 do
       resources :vendors, only: [:show]
+      resources :markets, only: [:index]
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_03_30_155211) do
+ActiveRecord::Schema[7.1].define(version: 0) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/factories/markets.rb
+++ b/spec/factories/markets.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     name { Faker::Company.name }
     street { Faker::Address.street_address }
     city { Faker::Address.city }
-    county { Faker::Address.county }
+    county { Faker::Address.community }
     state { Faker::Address.state }
     zip { Faker::Address.zip_code }
     lat { Faker::Address.latitude }

--- a/spec/models/market_spec.rb
+++ b/spec/models/market_spec.rb
@@ -16,4 +16,13 @@ RSpec.describe Market, type: :model do
     it { should have_many(:market_vendors) }
     it { should have_many(:vendors).through(:market_vendors) }
   end
+
+  describe '#vendor_count_calc' do
+    it 'returns the number of associated vendors' do
+      market = create(:market)  
+      create_list(:market_vendor, 5, market: market) 
+
+      expect(market.vendor_count_calc).to eq(5)
+    end
+  end
 end

--- a/spec/requests/api/v0/markets_spec.rb
+++ b/spec/requests/api/v0/markets_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V0::Markets", type: :request do
+  it "returns all markets" do
+    markets = create_list(:market, 3)
+    markets.each { |market| create_list(:market_vendor, 2, market: market) }
+    get '/api/v0/markets'
+
+    expect(response).to have_http_status(200)
+    json_response = JSON.parse(response.body)
+    expect(json_response['data'].count).to eq(3)
+  end
+
+  it "returns markets with correct attributes including vendor_count" do
+    markets = create_list(:market, 3)
+    markets.each { |market| create_list(:market_vendor, 2, market: market) }
+    get '/api/v0/markets'
+
+    json_response = JSON.parse(response.body)
+    expect(json_response['data'].first['attributes']).to include(
+      'name',
+      'street',
+      'city',
+      'county',
+      'state',
+      'zip',
+      'lat',
+      'lon',
+      'vendor_count'
+    )
+  end
+end


### PR DESCRIPTION
This PR adds a new feature which is returning all markets with the correct attributes in addition to vendor_count attribute.
The new attribute has a method in market model that calculates the number of vendors that are associated with each market.
